### PR TITLE
fix: Confirm email on sign up before sign in

### DIFF
--- a/components/auth-button.tsx
+++ b/components/auth-button.tsx
@@ -6,7 +6,7 @@ import { useSupabase } from "@/lib/supabase-provider"
 import { useRouter } from "next/navigation"
 import { Loader2, LogOut } from "lucide-react"
 import { AuthModal } from "@/components/auth-modal"
-import { useToast } from "@/hooks/use-toast"
+import { useToastContext } from "@/components/toast-provider"
 
 interface AuthButtonProps {
   className?: string
@@ -20,7 +20,7 @@ export function AuthButton({ className, variant = "default", showSignUp = true }
   const [showAuthModal, setShowAuthModal] = useState(false)
   const [authModalTab, setAuthModalTab] = useState<"signin" | "signup">("signin")
   const router = useRouter()
-  const { toast } = useToast()
+  const { success, error: showError } = useToastContext()
 
   const handleSignOut = async () => {
     try {
@@ -29,19 +29,12 @@ export function AuthButton({ className, variant = "default", showSignUp = true }
 
       if (error) throw error
 
-      toast({
-        title: "Signed out successfully",
-        description: "You have been signed out of your account.",
-      })
+      success("Signed out successfully")
 
       router.refresh()
     } catch (error: any) {
       console.error("Error signing out:", error)
-      toast({
-        title: "Error signing out",
-        description: error.message || "An error occurred while signing out",
-        variant: "destructive",
-      })
+      showError(error.message || "An error occurred while signing out")
     } finally {
       setIsLoading(false)
     }

--- a/components/auth-modal.tsx
+++ b/components/auth-modal.tsx
@@ -71,12 +71,18 @@ export function AuthModal({ isOpen, onClose, defaultTab = "signin" }: AuthModalP
         throw new Error("Email and password are required")
       }
 
-      const { error } = await supabase.auth.signInWithPassword({
+      const { data, error } = await supabase.auth.signInWithPassword({
         email,
         password,
       })
 
-      if (error) throw error
+      if (error) {
+        if (error.message?.toLowerCase().includes("email not confirmed")) {
+          setError("You still need to confirm your address – check your inbox or spam folder.")
+          return
+        }
+        throw error
+      }
 
       success("Signed in successfully - Welcome back!")
 
@@ -104,13 +110,18 @@ export function AuthModal({ isOpen, onClose, defaultTab = "signin" }: AuthModalP
         throw new Error("Password must be at least 6 characters")
       }
 
-      const { error } = await supabase.auth.signUp({
+      // Get the current URL for the redirect
+      const origin =
+        typeof window !== "undefined" && window.location.hostname === "localhost"
+          ? window.location.origin
+          : process.env.NEXT_PUBLIC_SITE_URL || "https://allstarluxuryrentals-jaanavs-projects.vercel.app"
+
+      const { data, error } = await supabase.auth.signUp({
         email,
         password,
         options: {
-          data: {
-            full_name: name,
-          },
+          data: { full_name: name },
+          emailRedirectTo: `${origin}/auth/callback`,
         },
       })
 


### PR DESCRIPTION
Tested out the sign in/out/up flows. Found that users were able to sign in after signing up without confirming their email. This should fix that.

Fixes:

1. auth-modal.tsx: Created a callback URL and used it to define the "emailRedirectTo" attribute on the signUp request JSON. 
2. auth-button.tsx: Fixed the toast message issue. In order for the toast popup to show up, we need to be using "useToastContext". "useToast" is responsible for toast state management whereas "useToastContext" uses "useToast" for state management as well as renders the actual message. 